### PR TITLE
fix: device ingests socket information on info() call

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   "homepage": "https://github.com/sciencecorp/synapse-typescript#readme",
   "devDependencies": {
     "eslint": "^9.5.0",
-    "protobufjs-cli": "^1.1.2",
     "typescript": "^5.5.2"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.10.10",
     "@grpc/proto-loader": "^0.7.13",
     "google-protobuf": "^3.21.2",
+    "protobufjs-cli": "^1.1.2",
     "yargs": "^17.7.2"
   }
 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -42,7 +42,11 @@ class Device {
         if (err) {
           reject(err);
         } else {
-          resolve(res!);
+          if (this._handleStatusResponse(res.status)) {
+            resolve(res!);
+          } else {
+            reject(`Error starting device: (code: ${getName(synapse.StatusCode, res.code)}) ${res.message}`);
+          }
         }
       });
     });


### PR DESCRIPTION
allowing users to instantiate and run stream out nodes without needing to configure the device first