### PR TITLE
fix: sha parsing and rate limiting on postinstall script

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -43,3 +43,15 @@ jobs:
       - name: Test
         run: npm run test
         shell: bash
+
+  test-install:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.13.0"
+
+      - name: Test Installation
+        run: npm install git://github.com/sciencecorp/synapse-typescript.git#${{ github.sha }}
+        shell: bash

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -55,3 +55,17 @@ jobs:
       - name: Test Installation
         run: npm install git://github.com/sciencecorp/synapse-typescript.git#${{ github.sha }}
         shell: bash
+
+  test-install-with-token:
+    runs-on: ${{ inputs.runner }}
+    env:
+      SCIENCE_CORPORATION_SYNAPSE_TOKEN: ${{ secrets.SCIENCECORP_SYNAPSE_READ_TOKEN }}
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.13.0"
+
+      - name: Test Installation
+        run: npm install git://github.com/sciencecorp/synapse-typescript.git#${{ github.sha }}
+        shell: bash

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -39,8 +39,16 @@ fi
 
 echo "- Looking up synapse-api ref for synapse-typescript ref $REF_LIB"
 
+CURL_OPTS=()
+CURL_OPTS+=(-H "Accept: application/vnd.github+json")
+CURL_OPTS+=(-H "X-GitHub-Api-Version: 2022-11-28")
+if [ -n "$SCIENCE_CORPORATION_SYNAPSE_TOKEN" ]; then
+    echo " - Using GitHub token for authentication"
+    CURL_OPTS+=(-H "Authorization: Bearer $SCIENCE_CORPORATION_SYNAPSE_TOKEN")
+fi
+
 echo " - Fetching synapse-api submodule info..."
-CURL_RESULT=$(curl -s "https://api.github.com/repos/sciencecorp/synapse-typescript/contents/synapse-api?ref=$REF_LIB")
+CURL_RESULT=$(curl -s "${CURL_OPTS[@]}" "https://api.github.com/repos/sciencecorp/synapse-typescript/contents/synapse-api?ref=$REF_LIB")
 if [ -z "$CURL_RESULT" ]; then
     echo "   - Failed to fetch from GitHub API"
     exit 1

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -39,13 +39,29 @@ fi
 
 echo "- Looking up synapse-api ref for synapse-typescript ref $REF_LIB"
 
-REF_API=$(curl -s "https://api.github.com/repos/sciencecorp/synapse-typescript/contents/synapse-api?ref=$REF_LIB" | grep -o '"sha": *"[^"]*"' | sed 's/"sha": *"\([^"]*\)"/\1/')
-if [ -z "$REF_API" ]; then
-    echo " - Failed to get synapse-api version"
+echo " - Fetching synapse-api submodule info..."
+CURL_RESULT=$(curl -s "https://api.github.com/repos/sciencecorp/synapse-typescript/contents/synapse-api?ref=$REF_LIB")
+if [ -z "$CURL_RESULT" ]; then
+    echo "   - Failed to fetch from GitHub API"
     exit 1
 fi
 
-echo "- Found synapse-api ref $REF_API"
+echo "   - Parsing SHA from response..."
+GREP_RESULT=$(echo "$CURL_RESULT" | grep -o '"sha":\s*"[^"]*"')
+if [ -z "$GREP_RESULT" ]; then
+    echo "   - Failed to find SHA in API response"
+    echo "   - API response: $CURL_RESULT"
+    exit 1
+fi
+
+REF_API=$(echo "${GREP_RESULT#*:}" | tr -d '[:space:]"')
+if [ -z "$REF_API" ]; then
+    echo "   - Failed to parse SHA from API response"
+    echo "   - API response: $CURL_RESULT"
+    exit 1
+fi
+
+echo "- Found synapse-api ref \"$REF_API\""
 
 TMP_DIR=$(mktemp -d)
 if ! curl -s -L "https://github.com/sciencecorp/synapse-api/archive/${REF_API}.zip" -o "$TMP_DIR/synapse-api.zip"; then
@@ -68,4 +84,4 @@ if [ ! -f "synapse-api/README.md" ] || [ ! -f "synapse-api/COPYRIGHT" ] || [ ! -
     echo " - Failed to download synapse-api - missing required files"
     exit 1
 fi
-echo " - Successfully downloaded synapse-api ref $REF_API"
+echo " - Successfully downloaded synapse-api ref \"$REF_API\""


### PR DESCRIPTION
- fix sha parsing API response -- handle spaces (was an issue in macos runners, not ubuntu or local macos strangely)
- add ability to specify github token (for more generous github api rate limits; rate limiting encountered in CI)
- add test install jobs