### PR TITLE
feat: add Status obj, return status from Device and Config calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ console.log("Device info: ", info);
 
 const streamOut = new StreamOut(
   {
-    multicastGroup: "239.0.0.1",
+    multicastGroup: "224.0.0.1",
   },
   (msg: Buffer) => {
     console.log("StreamOut | recv: ", msg);

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repo contains the Node client for the [Synapse API](https://science.xyz/technologies/synapse). More information about the API can be found in the [docs](https://science.xyz/docs/d/synapse/index).
 
+## Installation
+
+```sh
+npm i @science-corporation/synapse
+```
+
+```typescript
+import { Config, Device, StreamOut, BroadbandSource } from "@science-corporation/synapse";
+```
+
+This repo wraps a gRPC client and so is not compatible with browser environments. However, utils and types may still be used in browser contexts with the `browser` export.
+
+```typescript
+import { Status, StatusCode, BroadbandSource, StreamOut } from "@science-corporation/synapse/browser";
+```
+
 ## Building
 
 ### Prerequisites

--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "default": "./dist/browser.js"
+    }
+  },
   "files": [
     "dist",
     "scripts",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,4 @@
+// Browser-safe exports (types and enums only)
+export type { CallOptions } from "./utils/client";
+export { IStatus, Status, StatusCode } from "./utils/status";
+export * from "./api/api";

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -294,7 +294,12 @@ const main = async () => {
   console.log(`Connecting to device @ ${uri}`);
   const device = new Device(uri as string);
 
-  await info(device);
+  try {
+    await info(device);
+  } catch (err) {
+    console.error(`Failed to get device info (${err.code}): ${err.message}`);
+    return;
+  }
 
   if (argv._.includes("read")) {
     return read(device, argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { default as Config } from "./config";
 export { default as Device } from "./device";
-export { CallOptions } from "./utils/client";
 export * from "./nodes";
-export * from "./types";
+export { IStatus, Status, StatusCode } from "./utils/status";
+
+export type { CallOptions } from "./utils/client";
+export * from "./api/api";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Config } from "./config";
-export { default as Device, CallOptions } from "./device";
+export { default as Device } from "./device";
+export { CallOptions } from "./utils/client";
 export * from "./nodes";
 export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { default as Config } from "./config";
 export { default as Device, CallOptions } from "./device";
 export * from "./nodes";
-export * from "./api/api";
+export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export * from "./api/api";
+export * from "./api-science-device/api";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,0 @@
-export * from "./api/api";
-export * from "./api-science-device/api";

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,20 +1,45 @@
 import { ChannelCredentials, ChannelOptions, loadPackageDefinition } from "@grpc/grpc-js";
 import { fromJSON } from "@grpc/proto-loader";
+import { Status, StatusCode } from "./status";
 
-import protoJson from "../api/proto.json";
+export interface CallOptions {
+  deadline?: Date;
+}
 
-const loadClient = () => {
-  const definition = fromJSON(protoJson as any, {
-    keepCase: false,
-    arrays: true,
-    enums: Number,
-    defaults: true,
-    oneofs: true,
-  });
-  const descriptor = loadPackageDefinition(definition as any);
-  return (descriptor.synapse as any).SynapseDevice;
+const pick = (obj: any, path: string) => {
+  return path.split(".").reduce((acc, part) => (acc && acc[part]) || null, obj);
 };
 
-export const create = (address: string, credentials: ChannelCredentials, options?: ChannelOptions) => {
-  return new (loadClient())(address, credentials, options);
+const loadClient = (protoJson: object, serviceName: string): { status: Status; factory?: any } => {
+  try {
+    const definition = fromJSON(protoJson as any, {
+      keepCase: false,
+      arrays: true,
+      enums: Number,
+      defaults: true,
+      oneofs: true,
+    });
+
+    const descriptor = loadPackageDefinition(definition as any);
+
+    const service = pick(descriptor, serviceName);
+    if (!service) {
+      return { status: new Status(StatusCode.INTERNAL, `service ${serviceName} not found in proto definition`) };
+    }
+
+    return { status: new Status(StatusCode.OK), factory: service };
+  } catch (error) {
+    return { status: new Status(StatusCode.INTERNAL, "failed to load proto definition: " + error) };
+  }
 };
+
+export const create =
+  (protoJson: object, serviceName: string) =>
+  (address: string, credentials: ChannelCredentials, options?: ChannelOptions): { status: Status; client?: any } => {
+    const { status, factory } = loadClient(protoJson, serviceName);
+    if (!status.ok()) {
+      return { status };
+    }
+    const client = new factory(address, credentials, options);
+    return { status, client };
+  };

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,15 +1,31 @@
-import { status as StatusCode } from "@grpc/grpc-js";
+import { Status as StatusCode } from "@grpc/grpc-js/build/src/constants";
 import { synapse } from "../api/api";
 
-class Status {
-  constructor(public code: StatusCode = StatusCode.OK, public message: string = "") {}
+export interface IStatus {
+  code: StatusCode;
+  message: string;
+}
 
-  static fromProto(proto: any) {
-    return new Status(proto.code, proto.message);
-  }
+class Status implements IStatus {
+  constructor(public code: StatusCode = StatusCode.OK, public message: string = "") {}
 
   ok() {
     return this.code === StatusCode.OK;
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+    };
+  }
+
+  static fromJSON(json: { code: StatusCode; message: string }) {
+    return new Status(json.code, json.message);
+  }
+
+  static fromProto(proto: any) {
+    return new Status(proto.code, proto.message);
   }
 }
 

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,0 +1,41 @@
+import { status as StatusCode } from "@grpc/grpc-js";
+import { synapse } from "../api/api";
+
+class Status {
+  constructor(public code: StatusCode = StatusCode.OK, public message: string = "") {}
+
+  static fromProto(proto: any) {
+    return new Status(proto.code, proto.message);
+  }
+
+  ok() {
+    return this.code === StatusCode.OK;
+  }
+}
+
+export const fromDeviceStatusCode = (status: synapse.StatusCode) => {
+  switch (status) {
+    case synapse.StatusCode.kOk:
+      return StatusCode.OK;
+    case synapse.StatusCode.kInvalidConfiguration:
+      return StatusCode.INVALID_ARGUMENT;
+    case synapse.StatusCode.kFailedPrecondition:
+      return StatusCode.FAILED_PRECONDITION;
+    case synapse.StatusCode.kUnimplemented:
+      return StatusCode.UNIMPLEMENTED;
+    case synapse.StatusCode.kInternalError:
+      return StatusCode.INTERNAL;
+    case synapse.StatusCode.kPermissionDenied:
+      return StatusCode.PERMISSION_DENIED;
+    case synapse.StatusCode.kUndefinedError:
+    case synapse.StatusCode.kQueryFailed:
+    default:
+      return StatusCode.UNKNOWN;
+  }
+};
+
+export const fromDeviceStatus = ({ code, message }: { code: synapse.StatusCode; message?: string }) => {
+  return new Status(fromDeviceStatusCode(code), message);
+};
+
+export { Status, StatusCode };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -13,14 +13,16 @@ describe("Config", () => {
   describe("addNode", () => {
     it("should add a node with auto-generated id", () => {
       const node = new BroadbandSource();
-      expect(config.addNode(node)).toBe(true);
+      const status = config.addNode(node);
+      expect(status.ok()).toBe(true);
       expect(node.id).toBe(1);
       expect(config.nodes).toContain(node);
     });
 
     it("should add a node with specified id", () => {
       const node = new BroadbandSource();
-      expect(config.addNode(node, 5)).toBe(true);
+      const status = config.addNode(node, 5);
+      expect(status.ok()).toBe(true);
       expect(node.id).toBe(5);
       expect(config.nodes).toContain(node);
     });
@@ -28,15 +30,20 @@ describe("Config", () => {
     it("should reject node that already has an id", () => {
       const node = new BroadbandSource();
       node.id = 1;
-      expect(config.addNode(node)).toBe(false);
+      const status = config.addNode(node);
+      expect(status.ok()).toBe(false);
       expect(config.nodes).not.toContain(node);
     });
 
     it("should reject duplicate node ids", () => {
       const node1 = new BroadbandSource();
       const node2 = new BroadbandSource();
-      config.addNode(node1, 1);
-      expect(config.addNode(node2, 1)).toBe(false);
+
+      let status = config.addNode(node1, 1);
+      expect(status.ok()).toBe(true);
+
+      status = config.addNode(node2, 1);
+      expect(status.ok()).toBe(false);
     });
   });
 
@@ -44,17 +51,23 @@ describe("Config", () => {
     it("should connect two nodes", () => {
       const node1 = new BroadbandSource();
       const node2 = new SpikeDetect();
-      config.addNode(node1);
-      config.addNode(node2);
 
-      expect(config.connect(node1, node2)).toBe(true);
+      let status = config.addNode(node1);
+      expect(status.ok()).toBe(true);
+
+      status = config.addNode(node2);
+      expect(status.ok()).toBe(true);
+
+      status = config.connect(node1, node2);
+      expect(status.ok()).toBe(true);
       expect(config.connections).toContainEqual([node1.id, node2.id]);
     });
 
     it("should reject connection if nodes don't have ids", () => {
       const node1 = new BroadbandSource();
       const node2 = new SpikeDetect();
-      expect(config.connect(node1, node2)).toBe(false);
+      const status = config.connect(node1, node2);
+      expect(status.ok()).toBe(false);
       expect(config.connections).toHaveLength(0);
     });
   });
@@ -62,7 +75,8 @@ describe("Config", () => {
   describe("add", () => {
     it("should add multiple nodes", () => {
       const nodes = [new BroadbandSource(), new SpikeDetect()];
-      expect(config.add(nodes)).toBe(true);
+      const status = config.add(nodes);
+      expect(status.ok()).toBe(true);
       expect(config.nodes).toHaveLength(2);
       expect(nodes[0].id).toBe(1);
       expect(nodes[1].id).toBe(2);
@@ -71,7 +85,8 @@ describe("Config", () => {
     it("should fail if any node already has an id", () => {
       const nodes = [new BroadbandSource(), new SpikeDetect()];
       nodes[1].id = 5;
-      expect(config.add(nodes)).toBe(false);
+      const status = config.add(nodes);
+      expect(status.ok()).toBe(false);
       expect(config.nodes).toHaveLength(1);
     });
   });
@@ -172,7 +187,8 @@ describe("Config", () => {
       config.add([node1, node2]);
 
       const mockDevice = { id: "test-device" };
-      expect(config.setDevice(mockDevice)).toBe(true);
+      const status = config.setDevice(mockDevice);
+      expect(status.ok()).toBe(true);
 
       expect(node1.device).toBe(mockDevice);
       expect(node2.device).toBe(mockDevice);

--- a/tests/utils/status.test.ts
+++ b/tests/utils/status.test.ts
@@ -1,0 +1,24 @@
+import { synapse } from "../../src/api/api";
+import { fromDeviceStatusCode, StatusCode } from "../../src/utils/status";
+
+describe("status", () => {
+  describe("fromDeviceStatusCode", () => {
+    const cases = [
+      { input: synapse.StatusCode.kOk, expected: StatusCode.OK },
+      { input: synapse.StatusCode.kInvalidConfiguration, expected: StatusCode.INVALID_ARGUMENT },
+      { input: synapse.StatusCode.kFailedPrecondition, expected: StatusCode.FAILED_PRECONDITION },
+      { input: synapse.StatusCode.kUnimplemented, expected: StatusCode.UNIMPLEMENTED },
+      { input: synapse.StatusCode.kInternalError, expected: StatusCode.INTERNAL },
+      { input: synapse.StatusCode.kPermissionDenied, expected: StatusCode.PERMISSION_DENIED },
+      { input: synapse.StatusCode.kUndefinedError, expected: StatusCode.UNKNOWN },
+      { input: synapse.StatusCode.kQueryFailed, expected: StatusCode.UNKNOWN },
+      { input: 999 as synapse.StatusCode, expected: StatusCode.UNKNOWN },
+    ];
+
+    cases.forEach(({ input, expected }) => {
+      it(`should convert ${synapse.StatusCode[input] || input} to ${StatusCode[expected]}`, () => {
+        expect(fromDeviceStatusCode(input)).toBe(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
feat: add 'browser' export so that enums and types may be consumed in browser environments (the rest of the lib requires node for grpc-based internals)