### PR TITLE
Bump synapse-api to 551e247 and release 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@science-corporation/synapse",
-  "version": "2.2.9",
+  "version": "2.3.0",
   "description": "Client library and CLI for the Synapse API",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Picks up #78 (generalize DeviceSettings to a values Struct + schema) and #77 (Image Source/Sink). Regenerated proto types reflect the new DeviceSettings shape (`values?: google.protobuf.IStruct`). No edits needed in src/device.ts since updateDeviceSettings passes IDeviceSettings straight through to the RPC.