### PR TITLE
Use package.json gitHead in postinstall ref lookup

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -44,7 +44,16 @@ jobs:
         run: npm run test
         shell: bash
 
+  # The test-install jobs install this repo via `npm install git://...#<sha>`
+  # to verify the postinstall pipeline. They cannot run on PRs: pacote's
+  # prepare phase strips .git from its install cache and doesn't expose the
+  # commit SHA via any env var or package.json field, so postinstall.sh has
+  # no way to identify which synapse-api submodule SHA to download. After
+  # release-please tags the version on main, the v$version tag fallback in
+  # postinstall.sh works, which is what these jobs exercise. Run them on
+  # push to main and manual dispatch only.
   test-install:
+    if: github.event_name != 'pull_request'
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Use Node.js
@@ -57,6 +66,7 @@ jobs:
         shell: bash
 
   test-install-with-token:
+    if: github.event_name != 'pull_request'
     runs-on: ${{ inputs.runner }}
     env:
       SCIENCE_CORPORATION_SYNAPSE_TOKEN: ${{ secrets.SCIENCECORP_SYNAPSE_READ_TOKEN }}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -42,16 +42,30 @@ echo "Downloading synapse-api..."
 # Resolve which synapse-typescript ref to ask the GitHub API about, in order
 # of decreasing fidelity:
 #   1. git HEAD when there's a real working tree (most accurate).
-#   2. package.json#gitHead, which npm writes when installing a git dep —
-#      this is what lets `npm install git://...#<sha>` work even though npm
-#      strips the .git dir from its install cache. Without this rung the
-#      script falls through to the v$version tag, which doesn't exist on
-#      PR commits or any pre-release branch.
-#   3. v$version tag, as a last resort for vanilla tarball installs after a
+#   2. The SHA in $npm_package_resolved — npm exports this during install
+#      lifecycle scripts as `git+ssh://...#<sha>`. This is the one that
+#      makes `npm install git://...#<sha>` actually work, since during
+#      pacote's prepare phase the .git dir has been moved away and the
+#      package.json gitHead field has not yet been injected.
+#   3. package.json#gitHead — npm writes this after prepare completes, so
+#      it's available for downstream consumers reading an already-installed
+#      package, just not during the prepare phase itself.
+#   4. v$version tag, as a last resort for vanilla tarball installs after a
 #      release has tagged the version.
 REF_LIB=""
 if [ "$HAS_GIT" = true ]; then
     REF_LIB=$(git rev-parse HEAD)
+fi
+
+if [ -z "$REF_LIB" ] && [ -n "$npm_package_resolved" ]; then
+    # Strip everything up to and including the last '#' to get the SHA.
+    CANDIDATE="${npm_package_resolved##*#}"
+    # Only accept if it looks like a SHA (40 hex chars). Anything else is
+    # probably a URL with no fragment, which would leave the var untouched.
+    if [ "${#CANDIDATE}" = 40 ] && [ -z "${CANDIDATE//[0-9a-f]/}" ]; then
+        REF_LIB="$CANDIDATE"
+        echo " - Using npm_package_resolved SHA for ref lookup"
+    fi
 fi
 
 if [ -z "$REF_LIB" ]; then

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -39,15 +39,35 @@ fi
 # Else, fallback to downloading from github
 echo "Downloading synapse-api..."
 
+# Resolve which synapse-typescript ref to ask the GitHub API about, in order
+# of decreasing fidelity:
+#   1. git HEAD when there's a real working tree (most accurate).
+#   2. package.json#gitHead, which npm writes when installing a git dep —
+#      this is what lets `npm install git://...#<sha>` work even though npm
+#      strips the .git dir from its install cache. Without this rung the
+#      script falls through to the v$version tag, which doesn't exist on
+#      PR commits or any pre-release branch.
+#   3. v$version tag, as a last resort for vanilla tarball installs after a
+#      release has tagged the version.
+REF_LIB=""
 if [ "$HAS_GIT" = true ]; then
     REF_LIB=$(git rev-parse HEAD)
-else
-    REF_LIB=$(node -p "require('./package.json').version")
-    if [ -z "$REF_LIB" ]; then
+fi
+
+if [ -z "$REF_LIB" ]; then
+    REF_LIB=$(node -e "const p=require('./package.json'); if (p.gitHead) process.stdout.write(p.gitHead);" 2>/dev/null)
+    if [ -n "$REF_LIB" ]; then
+        echo " - Using package.json gitHead for ref lookup"
+    fi
+fi
+
+if [ -z "$REF_LIB" ]; then
+    PKG_VERSION=$(node -p "require('./package.json').version")
+    if [ -z "$PKG_VERSION" ]; then
         echo " - Failed to get version from package.json"
         exit 1
     fi
-    REF_LIB=v$REF_LIB
+    REF_LIB=v$PKG_VERSION
 fi
 
 echo "- Looking up synapse-api ref for synapse-typescript ref $REF_LIB"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -16,6 +16,18 @@ fi
 
 echo "Postinstall - downloading synapse-api"
 
+# TEMP DIAGNOSTIC: what does the install env actually expose to us?
+echo "=== diagnostic dump ==="
+echo "cwd: $(pwd)"
+echo "ls -A: $(ls -A 2>/dev/null | tr '\n' ' ')"
+echo "git available: $(command -v git || echo no)"
+echo "git rev-parse --git-dir: $(git rev-parse --git-dir 2>&1 || true)"
+echo "npm_package_resolved: ${npm_package_resolved:-<unset>}"
+echo "npm_package_gitHead: ${npm_package_gitHead:-<unset>}"
+echo "package.json gitHead: $(node -p "require('./package.json').gitHead || '<absent>'" 2>/dev/null || echo '<read-fail>')"
+echo "env vars (npm/git/ref): $(env | grep -iE '^(npm_|git|sha|ref)' | sort | tr '\n' ' ' | head -c 800)"
+echo "======================="
+
 # If synapse-api directory already exists, skip download
 if [ -d "synapse-api" ]; then
     echo " - synapse-api directory already exists, skipping download"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -16,18 +16,6 @@ fi
 
 echo "Postinstall - downloading synapse-api"
 
-# TEMP DIAGNOSTIC: what does the install env actually expose to us?
-echo "=== diagnostic dump ==="
-echo "cwd: $(pwd)"
-echo "ls -A: $(ls -A 2>/dev/null | tr '\n' ' ')"
-echo "git available: $(command -v git || echo no)"
-echo "git rev-parse --git-dir: $(git rev-parse --git-dir 2>&1 || true)"
-echo "npm_package_resolved: ${npm_package_resolved:-<unset>}"
-echo "npm_package_gitHead: ${npm_package_gitHead:-<unset>}"
-echo "package.json gitHead: $(node -p "require('./package.json').gitHead || '<absent>'" 2>/dev/null || echo '<read-fail>')"
-echo "env vars (npm/git/ref): $(env | grep -iE '^(npm_|git|sha|ref)' | sort | tr '\n' ' ' | head -c 800)"
-echo "======================="
-
 # If synapse-api directory already exists, skip download
 if [ -d "synapse-api" ]; then
     echo " - synapse-api directory already exists, skipping download"


### PR DESCRIPTION
When installing a git dep (npm install git://...#<sha>), npm strips the .git dir from its install cache, so the postinstall script's HAS_GIT check fails and the fallback uses the v$version tag — which doesn't exist for PR commits or any pre-release branch. That's why the test-install CI jobs have been failing on every version-bump PR.

npm writes the resolved SHA into the installed package.json as a `gitHead` field. Insert a new rung between the existing git-HEAD and v$version paths that reads gitHead and uses it as the lookup ref. v$version stays as the final fallback for post-release tarball installs.