### PR TITLE
Pin shell scripts to LF, bump to 2.3.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Default: let git handle text files normally based on platform conventions.
+* text=auto
+
+# Shell scripts must check out with LF regardless of platform autocrlf
+# settings. These get packed into the published npm tarball and run on the
+# consumer's machine — usually Linux CI runners — where bash fails on CRLF
+# with `$'\r': command not found`. Without this rule, a contributor whose
+# Windows git is configured with autocrlf=true produces CRLF in their
+# working tree, and `npm publish` from that WT bakes CRLF into the tarball.
+*.sh text eol=lf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@science-corporation/synapse",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Client library and CLI for the Synapse API",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
The 2.3.0 tarball shipped scripts/postinstall.sh with CRLF line endings because npm publish was run from a Windows WT with git's autocrlf converting on checkout. Consumer installs on Linux then fail with `$'\r': command not found` at the first line of the script.

Add .gitattributes that pins *.sh to LF regardless of platform autocrlf settings, so any future publish from any environment produces a consistent tarball. Bump to 2.3.1 to roll out the fix.

Note for whoever publishes 2.3.1: after pulling this branch, the existing WT files are not automatically re-checked-out, so on Windows you may need to force the .gitattributes rules to take effect on the current WT:

  git rm --cached -- scripts/*.sh
  git checkout -- scripts/*.sh

Then verify with `file scripts/postinstall.sh` — it should not report "with CRLF line terminators" — before running npm publish.