### PR TITLE
Bump synapse-api submodule to 2.4.1 (impedance peripheral_id)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@science-corporation/synapse",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Client library and CLI for the Synapse API",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/src/api_version.ts
+++ b/src/api_version.ts
@@ -1,2 +1,2 @@
 // Generated from synapse-api/VERSION by scripts/generate.sh. Do not edit.
-export const SYNAPSE_API_VERSION = "2.4.0";
+export const SYNAPSE_API_VERSION = "2.4.1";


### PR DESCRIPTION
Picks up the new ImpedanceQuery.peripheral_id field. Consumers constructing impedance queries (nexus-desktop, etc.) can now set peripheral_id on the regenerated pbjs binding.

Refreshes src/api_version.ts to match the new VERSION (2.4.1).